### PR TITLE
Fix popup backdrop transition bug

### DIFF
--- a/animation/02-pop-up/style.css
+++ b/animation/02-pop-up/style.css
@@ -57,9 +57,9 @@ button {
   inset: 0;
   background: rgba(0, 0, 0, 0.3);
   opacity: 0;
-  transition: opacity 0.3;
+  transition: opacity 0.3s;
 }
 
 .backdrop.show {
-  opacity: 0.3 /* Visible when .show is added */
+  opacity: 0.3; /* Visible when .show is added */
 }


### PR DESCRIPTION
## Summary
- fix missing time unit on popup backdrop transition
- add missing semicolon for backdrop's opacity property

## Testing
- `grep -n transition animation/02-pop-up/style.css`

------
https://chatgpt.com/codex/tasks/task_e_685f4b8e4c448328ae995a838221e6fc